### PR TITLE
Changed the call to edge/app/<id>/version to match api spec.

### DIFF
--- a/src/edge_app.ts
+++ b/src/edge_app.ts
@@ -27,7 +27,7 @@ export const GetEdgeApp = (id: number) => request<EdgeApp>(Endpoints.EdgeApp + '
 
 export const GetEdgeAppVersions = (appId: number, untagged?: boolean) => {
     const qs = untagged ? '?untagged=' + untagged : '';
-    return request(Endpoints.EdgeApp + '/' + appId + '/versions' + qs, {});
+    return request(Endpoints.EdgeApp + '/' + appId + '/version' + qs, {});
 };
 
 export const GetEdgeAppConfigOptions = (id: number, version: string) => {


### PR DESCRIPTION
The call was to versions (with an s) wich is not correct according to the API-spec.