### PR TITLE
Fix/format function value params

### DIFF
--- a/src/function_helpers.ts
+++ b/src/function_helpers.ts
@@ -2,9 +2,7 @@ import {sprintf} from 'sprintf-js';
 import { Functionx } from './functionx';
 import { LogEntry } from './log';
 
-export const formatFunctionValueStatus = (status: {[key: string]: LogEntry}, functionx: Functionx, topicKey?: string) => {
-    topicKey = topicKey ?? 'topic_read';
-
+export const formatFunctionValueStatus = (status: {[key: string]: LogEntry}, functionx: Functionx, topicKey = 'topic_read') => {
     if (functionx.meta[topicKey] && status[functionx.meta[topicKey]]) {
         const currentStatus = status[functionx.meta[topicKey]];
         return formatFunctionValue(currentStatus.value, functionx, topicKey);
@@ -24,7 +22,7 @@ export const getFunctionStates = (functionx: Functionx) =>
         return res;
     }, {});
 
-export const formatFunctionValue = (value: number, functionx: Functionx, topicKey?: string, labels?: {[key: string]: string}) =>{
+export const formatFunctionValue = (value: number, functionx: Functionx, topicKey = 'topic_read', labels?: {[key: string]: string}) =>{
     const topicFormat = functionx.meta?.[`format_${(topicKey ?? '')?.slice('topic_'.length)}`] ?? functionx.meta?.['format'];
 
     if (topicFormat) {

--- a/src/function_helpers.ts
+++ b/src/function_helpers.ts
@@ -24,7 +24,7 @@ export const getFunctionStates = (functionx: Functionx) =>
         return res;
     }, {});
 
-export const formatFunctionValue = (value: number, functionx: Functionx, topicKey: string, labels?: {[key: string]: string}) =>{
+export const formatFunctionValue = (value: number, functionx: Functionx, topicKey?: string, labels?: {[key: string]: string}) =>{
     const topicFormat = functionx.meta?.[`format_${(topicKey ?? '')?.slice('topic_'.length)}`] ?? functionx.meta?.['format'];
 
     if (topicFormat) {

--- a/src/function_helpers.ts
+++ b/src/function_helpers.ts
@@ -49,7 +49,7 @@ export const formatFunctionValue = (value: number, functionx: Functionx, topicKe
     if(labels && labels[stateKey]){
         return labels[stateKey];
     }
-    return stateKey;
+    return `function_value__${stateKey}`;
 };
 
 export const formatFunctionMessageStatus = (status: {[key: string]: LogEntry}, functionx: Functionx, topicKey = 'topic_read') => {


### PR DESCRIPTION
In the previous version there was nothing that returned the template string `function_value__${stateKey}`. This string can be handled by the front-end as an i18n translation key.