### PR TITLE
made if statement work with topics besieds topic_read

### DIFF
--- a/src/function_helpers.ts
+++ b/src/function_helpers.ts
@@ -64,7 +64,7 @@ export const formatFunctionMessageStatus = (status: {[key: string]: LogEntry}, f
 };
 
 export const getFunctionTimestampStatus = (status: {[key: string]: LogEntry}, functionx: Functionx, topicKey = 'topic_read') => {
-    if (functionx.meta.topic_read && status[functionx.meta[topicKey]]) {
+    if (functionx.meta[topicKey] && status[functionx.meta[topicKey]]) {
         return status[functionx.meta[topicKey]].timestamp;
     }
     return '---';

--- a/src/function_helpers.ts
+++ b/src/function_helpers.ts
@@ -64,7 +64,7 @@ export const formatFunctionMessageStatus = (status: {[key: string]: LogEntry}, f
 };
 
 export const getFunctionTimestampStatus = (status: {[key: string]: LogEntry}, functionx: Functionx, topicKey = 'topic_read') => {
-    if (topicKey.startsWith('topic_') && functionx.meta[topicKey] && status[functionx.meta[topicKey]]) {
+    if (topicKey.startsWith('topic_read') && functionx.meta[topicKey] && status[functionx.meta[topicKey]]) {
         return status[functionx.meta[topicKey]].timestamp;
     }
     return '---';

--- a/src/function_helpers.ts
+++ b/src/function_helpers.ts
@@ -64,7 +64,7 @@ export const formatFunctionMessageStatus = (status: {[key: string]: LogEntry}, f
 };
 
 export const getFunctionTimestampStatus = (status: {[key: string]: LogEntry}, functionx: Functionx, topicKey = 'topic_read') => {
-    if (functionx.meta[topicKey] && status[functionx.meta[topicKey]]) {
+    if (topicKey.startsWith('topic_') && functionx.meta[topicKey] && status[functionx.meta[topicKey]]) {
         return status[functionx.meta[topicKey]].timestamp;
     }
     return '---';


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e915870d-9e57-4b27-adc5-b00eb684cce6)
The topics in the image above would not cause the function to return anything besides '---' prior if function meta didn't have a key called topic_read. Changing this to functionx.meta[topic_key] should allow other topics even if no topicKey parameter is provided as it defaults to being topic_read.